### PR TITLE
エラー時に表示する「再送する」ボタンの実装と再送機能の追加

### DIFF
--- a/app/api/helloworld/route.ts
+++ b/app/api/helloworld/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * モックAPI: Hello Worldエンドポイント
+ * GET /api/helloworld
+ */
+export async function GET(_: NextRequest) {
+  return NextResponse.json(
+    {"message": "Hello World"},
+    { status: 500 }
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import RightPanel from "@/components/ui/RightPanel";
 import { useGenerate } from "@/hooks/useGenerate";
 
 export default function Home() {
-  const { result, isLoading, error, handleGenerate, handleRetry } = useGenerate();
+  const { result, isLoading, error, handleGenerate, handleRetry, handleResend } = useGenerate();
 
   return (
     <div className="min-h-screen flex flex-col bg-gray-50">
@@ -22,7 +22,7 @@ export default function Home() {
 
           {/* 右パネル */}
           <div className="h-full">
-            <RightPanel onRetry={handleRetry} isLoading={isLoading} result={result}  error={error} />
+            <RightPanel onRetry={handleRetry} onResend={handleResend} isLoading={isLoading} result={result}  error={error} />
           </div>
         </div>
       </main>

--- a/components/ui/RightPanel.tsx
+++ b/components/ui/RightPanel.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import Button from "./common/Button";
 import ActionButtons from "./rightpanel/ActionButtons";
 import ResultCard from "./rightpanel/ResultCard";
 import type { GenerateResponse } from "@/types/api";
 
 type RightPanelProps = {
   onRetry: (retryInstruction: string) => void,
+  onResend: () => void,
   result: GenerateResponse | null,
   isLoading: boolean,
   error: string | null,
@@ -14,7 +16,7 @@ type RightPanelProps = {
 /**
  * 右側の生成後のパネルコンポーネント
  */
-export default function RightPanel({ onRetry, result, isLoading, error }: RightPanelProps) {
+export default function RightPanel({ onRetry, onResend, result, isLoading, error }: RightPanelProps) {
   return (
     <div className="flex flex-col h-full bg-white m-1 p-6 rounded-xl border border-blue-100">
       {isLoading && (
@@ -31,6 +33,7 @@ export default function RightPanel({ onRetry, result, isLoading, error }: RightP
           <div className="text-center space-y-2 text-red-600">
             <p className="font-bold">エラーが発生しました</p>
             <p className="text-sm">{error}</p>
+            <Button color="blue" onClick={onResend}>再送する</Button>
           </div>
         </div>
       )}

--- a/hooks/useGenerate.tsx
+++ b/hooks/useGenerate.tsx
@@ -10,9 +10,19 @@ export function useGenerate() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // エラー用に再送のための最後のリクエストをここに格納しておく
+  const [lastRequest, setLastRequest] = useState<
+    {
+      type: 'generate' | 'retry', 
+      data: GenerateRequest["inputs"] | string,
+    }
+    | null>(null);
+
+  // 言い訳を生成する
   const handleGenerate = async (inputs: GenerateRequest["inputs"]) => {
     setIsLoading(true);
     setError(null);
+    setLastRequest({ type: 'generate', data: inputs });
 
     try {
       const payload: GenerateRequest = {
@@ -41,6 +51,7 @@ export function useGenerate() {
     }
   };
 
+  // もっと盛る
   const handleRetry = async (retryInstruction: string) => {
     if (!result) {
       setError("再生成できる結果がありません");
@@ -49,6 +60,7 @@ export function useGenerate() {
 
     setIsLoading(true);
     setError(null);
+    setLastRequest({ type: 'retry', data: retryInstruction });
 
     try {
       const payload: RetryRequest = {
@@ -78,5 +90,20 @@ export function useGenerate() {
     }
   };
 
-  return { result, isLoading, error, handleGenerate, handleRetry };
+  // 再送する
+  const handleResend = () => {
+    if (!lastRequest) return;
+
+    if (lastRequest.type === 'generate') {
+      handleGenerate(lastRequest.data as GenerateRequest["inputs"]);
+      return;
+    }
+    
+    if (lastRequest.type === 'retry') {
+      handleRetry(lastRequest.data as string);
+      return;
+    }
+  };
+
+  return { result, isLoading, error, handleGenerate, handleRetry, handleResend };
 }


### PR DESCRIPTION
再送ボタンは以下のものとなります。正常にバックエンドからデータを受け取れなかった場合などに再送することができます。
<img width="1012" height="764" alt="image" src="https://github.com/user-attachments/assets/61a8704b-2251-47ea-87e9-fd24b76a3a81" />
