### PR TITLE
feat: ヘッダーのポップデザインに合わせて全UIをリデザイン

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -20,7 +20,7 @@
 }
 
 body {
-  background: var(--background);
+  background: #f0fafa;
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
+  --background: #cffafe;
   --foreground: #171717;
 }
 
@@ -14,13 +14,13 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #ffffff;
+    --background: #cffafe;
     --foreground: #171717;
   }
 }
 
 body {
-  background: #f0fafa;
+  background-color: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,13 +10,13 @@ export default function Home() {
   const { result, isLoading, error, handleGenerate, handleRetry, handleResend } = useGenerate();
 
   return (
-    <div className="min-h-screen flex flex-col bg-gray-50">
+    <div className="min-h-screen flex flex-col">
       <Header />
       {/* メインコンテンツエリア
         - パソコン: 左右2カラムレイアウト
         - ケータイ: 上下レイアウト
       */}
-      <main className="flex-1 container mx-auto p-4 lg:p-6">
+      <main className="flex-1 container mx-auto px-4 pt-3 pb-4 lg:px-6 lg:pt-4 lg:pb-6">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 h-full">
           {/* 左パネル */}
           <div className="h-full">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,12 +8,12 @@ export default function Home() {
   const { result, isLoading, error, handleGenerate, handleRetry, handleResend } = useGenerate();
 
   return (
-    <div className="min-h-screen flex flex-col bg-gray-50">
+    <div className="min-h-screen flex flex-col">
       {/* メインコンテンツエリア
         - パソコン: 左右2カラムレイアウト
         - ケータイ: 上下レイアウト
         */}
-      <main className="flex-1 container mx-auto p-4 lg:p-6">
+      <main className="flex-1 container mx-auto px-4 pt-3 pb-4 lg:px-6 lg:pt-4 lg:pb-6">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 h-full">
           {/* 左パネル */}
           <div className="h-full">

--- a/components/ui/Footer.tsx
+++ b/components/ui/Footer.tsx
@@ -4,7 +4,7 @@
 export default function Footer() {
   return (
     <div className="z-10">
-      <div className="bg-white px-4 py-2 w-full border-3 border-gray-800 rounded-b-xl">
+      <div className="bg-white px-4 py-2 w-full border-[3px] border-gray-800 rounded-b-xl">
         <p className="font-black w-full text-center text-xs text-gray-800"><a href="https://github.com/toriaezu-yattemitai" target="_blank" rel="noopenner" className="underline">とりあえずやってみ隊</a> (Nishiwaki / Kaminakano / aid_913 / Murai / Ichi) @ 技育CAMP2026 ハッカソン Vol.1</p>
       </div>
     </div>

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -11,7 +11,7 @@ export default function Header() {
         background: 'repeating-linear-gradient(-45deg, #06b6d4, #06b6d4 10px, #67e8f9 10px, #67e8f9 20px)'
       }} />
       {/* タイトルバー */}
-      <div className="bg-white px-4 py-2 border-3 border-gray-800">
+      <div className="bg-white px-4 py-2 border-[3px] border-gray-800">
         <div className="flex items-center gap-2">
           {/* <span className="text-lg lg:text-2xl" aria-hidden="true">🌲💨🤧</span> */}
           <Image src="/icon.png" alt="アイコン" width={25} height={25} />

--- a/components/ui/LeftPanel.tsx
+++ b/components/ui/LeftPanel.tsx
@@ -109,7 +109,7 @@ export default function LeftPanel({ onGenerate, isLoading }: Props) {
   };
 
   return (
-    <div className="flex flex-col h-full bg-white m-1 p-6 rounded-xl border border-blue-100">
+    <div className="flex flex-col h-full bg-white m-1 p-6 rounded-xl border-3 border-gray-800">
       <div className="flex-1 space-y-6 overflow-y-auto">
         {/* 相手入力 */}
         <div className="space-y-2">

--- a/components/ui/LeftPanel.tsx
+++ b/components/ui/LeftPanel.tsx
@@ -8,6 +8,7 @@ import NumberSliderWithLabel from "./common/NumberSliderWithLabel";
 import type { GenerateRequest } from "@/types/api";
 import CheckBoxWithLabel from "./common/CheckBoxWithLabel";
 import ComboBoxWithLabel from "./common/ComboBoxWithLabel";
+import Label from "./common/Label";
 
 type Props = {
   onGenerate: (inputs: GenerateRequest["inputs"], options?: Partial<GenerateRequest["options"]>) => void,
@@ -110,7 +111,7 @@ export default function LeftPanel({ onGenerate, isLoading }: Props) {
   };
 
   return (
-    <div className="flex flex-col h-full bg-white m-2 p-6 rounded-xl border-3 border-gray-800 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+    <div className="flex flex-col h-full bg-white m-2 p-6 rounded-xl border-[3px] border-gray-800 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
       <div className="flex-1 space-y-6 overflow-y-auto">
         {/* 相手入力 */}
         <div className="space-y-2">
@@ -121,10 +122,7 @@ export default function LeftPanel({ onGenerate, isLoading }: Props) {
 
         {/* 症状入力 */}
         <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <label htmlFor="symptom" className="block text-sm font-black text-gray-800">症状</label>
-            <span className="text-xs font-black text-white bg-pink-500 px-1.5 py-0.5 rounded-md">必須</span>
-          </div>
+          <Label forId="symptom">症状 <span className="text-xs font-black text-white bg-pink-500 px-1.5 py-0.5 rounded-md">必須</span></Label>
           <TextBox id="symptom" placeholder="例：鼻水が止まらない" value={symptom} disabled={isLoading}
             onChange={(e) => setSymptom(e.target.value)}
           />

--- a/components/ui/LeftPanel.tsx
+++ b/components/ui/LeftPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Button from "./common/Button";
+import TextBox from "./common/TextBox";
 import TextBoxWithLabel from "./common/TextBoxWithLabel";
 import NumberSliderWithLabel from "./common/NumberSliderWithLabel";
 import type { GenerateRequest } from "@/types/api";
@@ -109,7 +110,7 @@ export default function LeftPanel({ onGenerate, isLoading }: Props) {
   };
 
   return (
-    <div className="flex flex-col h-full bg-white m-1 p-6 rounded-xl border-3 border-gray-800">
+    <div className="flex flex-col h-full bg-white m-2 p-6 rounded-xl border-3 border-gray-800 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
       <div className="flex-1 space-y-6 overflow-y-auto">
         {/* 相手入力 */}
         <div className="space-y-2">
@@ -120,7 +121,11 @@ export default function LeftPanel({ onGenerate, isLoading }: Props) {
 
         {/* 症状入力 */}
         <div className="space-y-2">
-          <TextBoxWithLabel id="symptom" label="症状" placeholder="例：鼻水が止まらない" value={symptom} disabled={isLoading}
+          <div className="flex items-center gap-2">
+            <label htmlFor="symptom" className="block text-sm font-black text-gray-800">症状</label>
+            <span className="text-xs font-black text-white bg-pink-500 px-1.5 py-0.5 rounded-md">必須</span>
+          </div>
+          <TextBox id="symptom" placeholder="例：鼻水が止まらない" value={symptom} disabled={isLoading}
             onChange={(e) => setSymptom(e.target.value)}
           />
         </div>
@@ -152,7 +157,7 @@ export default function LeftPanel({ onGenerate, isLoading }: Props) {
 
         {/* 位置情報取得の同意チェックボックス */}
         <div className="space-y-1 pt-2">
-          <div className="font-semibold flex items-start gap-3 p-4 bg-blue-50 rounded-lg border border-blue-100">
+          <div className="font-semibold flex items-start gap-3 p-4 bg-pink-50 rounded-xl border-2 border-pink-400">
             <CheckBoxWithLabel id="use-location" label="現在地の花粉データを取得する" checked={useLocation} disabled={isLoading} onChange={(e) => handleLocationCheckChange(e.target.checked)} />
           </div>
           {locationError ? (
@@ -166,8 +171,8 @@ export default function LeftPanel({ onGenerate, isLoading }: Props) {
       </div>
 
       {/* 生成ボタン */}
-      <div className="pt-6 mt-4 border-t border-gray-100">
-        <Button id="generate" onClick={handleSubmit} color="blue" disabled={isLoading}>
+      <div className="pt-6 mt-4 border-t-2 border-gray-200">
+        <Button id="generate" onClick={handleSubmit} color="pink" disabled={isLoading}>
           <span>{isLoading ? "生成中..." : "言い訳を生成する"}</span>
         </Button>
       </div>

--- a/components/ui/RightPanel.tsx
+++ b/components/ui/RightPanel.tsx
@@ -22,7 +22,7 @@ type Props = {
  */
 export default function RightPanel({ onRetry, onResend, result, isLoading, error }: Props) {
   return (
-    <div className="flex flex-col h-full bg-white m-1 p-6 rounded-xl border-3 border-gray-800">
+    <div className="flex flex-col h-full bg-white m-2 p-6 rounded-xl border-3 border-gray-800 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
       { /* 生成中 */ }
       {isLoading && <LoadingSection />}
 

--- a/components/ui/RightPanel.tsx
+++ b/components/ui/RightPanel.tsx
@@ -22,7 +22,7 @@ type Props = {
  */
 export default function RightPanel({ onRetry, onResend, result, isLoading, error }: Props) {
   return (
-    <div className="flex flex-col h-full bg-white m-2 p-6 rounded-xl border-3 border-gray-800 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+    <div className="flex flex-col h-full bg-white m-2 p-6 rounded-xl border-[3px] border-gray-800 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
       { /* 生成中 */ }
       {isLoading && <LoadingSection />}
 

--- a/components/ui/RightPanel.tsx
+++ b/components/ui/RightPanel.tsx
@@ -22,7 +22,7 @@ type Props = {
  */
 export default function RightPanel({ onRetry, onResend, result, isLoading, error }: Props) {
   return (
-    <div className="flex flex-col h-full bg-white m-1 p-6 rounded-xl border border-blue-100">
+    <div className="flex flex-col h-full bg-white m-1 p-6 rounded-xl border-3 border-gray-800">
       { /* 生成中 */ }
       {isLoading && <LoadingSection />}
 

--- a/components/ui/common/Badge.tsx
+++ b/components/ui/common/Badge.tsx
@@ -9,12 +9,12 @@ type BadgeProps = {
 };
 
 const colorClass: Record<string, string> = {
-    white: "bg-gray-100 text-black hover:bg-gray-300 border border-gray-400",
-    black: "bg-gray-500 text-white hover:bg-gray-400 border border-gray-700",
-    green: "bg-green-100 text-black hover:bg-green-200 border border-green-300",
-    blue: "bg-blue-100 text-black hover:bg-blue-200 border border-blue-300",
-    red: "bg-red-100 text-black hover:bg-red-200 border border-red-300",
-    yellow: "bg-yellow-100 text-black hover:bg-yellow-200 border border-yellow-300",
+    white: "bg-gray-100 text-gray-800 border-2 border-gray-800 font-bold",
+    black: "bg-gray-800 text-white border-2 border-gray-900 font-bold",
+    green: "bg-green-100 text-green-800 border-2 border-green-700 font-bold",
+    blue: "bg-cyan-100 text-cyan-800 border-2 border-cyan-700 font-bold",
+    red: "bg-red-100 text-red-800 border-2 border-red-700 font-bold",
+    yellow: "bg-yellow-100 text-yellow-800 border-2 border-yellow-600 font-bold",
 };
 
 /**

--- a/components/ui/common/Button.tsx
+++ b/components/ui/common/Button.tsx
@@ -16,12 +16,12 @@ const DEFAULT_CLASS_NAME = "w-full px-4 py-3 focus:outline-none cursor-pointer t
 
 const colorClass: Record<string, string> = {
     none: "",
-    white: "bg-white text-gray-700 hover:bg-gray-100 border border-gray-300",
-    black: "bg-black text-white hover:bg-gray-800",
-    green: "bg-green-500 text-white hover:bg-green-600",
-    blue: "bg-blue-500 text-white hover:bg-blue-600",
-    red: "bg-red-500 text-white hover:bg-red-600",
-    yellow: "bg-yellow-400 text-black hover:bg-yellow-500",
+    white: "bg-white text-gray-800 hover:bg-gray-100 border-2 border-gray-800 font-bold",
+    black: "bg-gray-800 text-white hover:bg-gray-900 font-bold",
+    green: "bg-pink-500 text-white hover:bg-pink-600 font-bold",
+    blue: "bg-cyan-500 text-white hover:bg-cyan-600 font-bold",
+    red: "bg-red-500 text-white hover:bg-red-600 font-bold",
+    yellow: "bg-yellow-400 text-gray-800 hover:bg-yellow-500 font-bold",
 };
 
 export default function Button({ id, onClick, color = "none", disabled = false, className = DEFAULT_CLASS_NAME, children }: Props) {

--- a/components/ui/common/Button.tsx
+++ b/components/ui/common/Button.tsx
@@ -6,27 +6,31 @@ import { ReactNode } from "react";
 type Props = {
     id?: string,
     onClick: () => void,
-    color?: "none" | "white" | "black" | "green" | "blue" | "red" | "yellow",
+    color?: "none" | "white" | "black" | "pink" | "green" | "blue" | "red" | "yellow",
     disabled?: boolean,
     className?: string,
     children: ReactNode,
 };
 
-const DEFAULT_CLASS_NAME = "w-full px-4 py-3 focus:outline-none cursor-pointer transition-all duration-300 ease-in-out rounded-xl flex items-center gap-2 justify-center disabled:opacity-50 disabled:cursor-not-allowed";
+const DEFAULT_CLASS_NAME = "w-full px-4 py-3 focus:outline-none cursor-pointer transition-all duration-200 ease-in-out rounded-xl flex items-center gap-2 justify-center disabled:opacity-50 disabled:cursor-not-allowed";
+
+const STYLED_CLASS_NAME = `${DEFAULT_CLASS_NAME} border-2 border-gray-800 shadow-[3px_3px_0px_0px_rgba(0,0,0,1)] active:shadow-none active:translate-[3px]`;
 
 const colorClass: Record<string, string> = {
-    none: "",
-    white: "bg-white text-gray-800 hover:bg-gray-100 border-2 border-gray-800 font-bold",
-    black: "bg-gray-800 text-white hover:bg-gray-900 font-bold",
-    green: "bg-pink-500 text-white hover:bg-pink-600 font-bold",
-    blue: "bg-cyan-500 text-white hover:bg-cyan-600 font-bold",
-    red: "bg-red-500 text-white hover:bg-red-600 font-bold",
-    yellow: "bg-yellow-400 text-gray-800 hover:bg-yellow-500 font-bold",
+    none: DEFAULT_CLASS_NAME,
+    white: `${STYLED_CLASS_NAME} bg-white text-gray-800 hover:bg-gray-100 font-bold`,
+    black: `${STYLED_CLASS_NAME} bg-gray-800 text-white hover:bg-gray-900 font-bold`,
+    pink: `${STYLED_CLASS_NAME} bg-pink-500 text-white hover:bg-pink-600 font-bold`,
+    blue: `${STYLED_CLASS_NAME} bg-cyan-500 text-white hover:bg-cyan-600 font-bold`,
+    green: `${STYLED_CLASS_NAME} bg-cyan-500 text-white hover:bg-cyan-600 font-bold`, // blue の別名（後方互換）
+    red: `${STYLED_CLASS_NAME} bg-red-500 text-white hover:bg-red-600 font-bold`,
+    yellow: `${STYLED_CLASS_NAME} bg-yellow-400 text-gray-800 hover:bg-yellow-500 font-bold`,
 };
 
-export default function Button({ id, onClick, color = "none", disabled = false, className = DEFAULT_CLASS_NAME, children }: Props) {
+export default function Button({ id, onClick, color = "none", disabled = false, className, children }: Props) {
+    const cls = className ?? colorClass[color] ?? DEFAULT_CLASS_NAME;
     return (
-        <button type="button" id={id} onClick={onClick} disabled={disabled} className={`${className} ${colorClass[color]}`}>
+        <button type="button" id={id} onClick={onClick} disabled={disabled} className={cls}>
             {children}
         </button>
     );

--- a/components/ui/common/Button.tsx
+++ b/components/ui/common/Button.tsx
@@ -19,10 +19,10 @@ const STYLED_CLASS_NAME = `${DEFAULT_CLASS_NAME} border-2 border-gray-800 shadow
 const colorClass: Record<string, string> = {
     none: DEFAULT_CLASS_NAME,
     white: `${STYLED_CLASS_NAME} bg-white text-gray-800 hover:bg-gray-100 font-bold`,
-    black: `${STYLED_CLASS_NAME} bg-gray-800 text-white hover:bg-gray-900 font-bold`,
+    black: `${STYLED_CLASS_NAME} bg-gray-600 text-white hover:bg-gray-900 font-bold`,
     pink: `${STYLED_CLASS_NAME} bg-pink-500 text-white hover:bg-pink-600 font-bold`,
     blue: `${STYLED_CLASS_NAME} bg-cyan-500 text-white hover:bg-cyan-600 font-bold`,
-    green: `${STYLED_CLASS_NAME} bg-cyan-500 text-white hover:bg-cyan-600 font-bold`, // blue の別名（後方互換）
+    green: `${STYLED_CLASS_NAME} bg-green-500 text-white hover:bg-cyan-600 font-bold`,
     red: `${STYLED_CLASS_NAME} bg-red-500 text-white hover:bg-red-600 font-bold`,
     yellow: `${STYLED_CLASS_NAME} bg-yellow-400 text-gray-800 hover:bg-yellow-500 font-bold`,
 };

--- a/components/ui/common/CheckBox.tsx
+++ b/components/ui/common/CheckBox.tsx
@@ -13,7 +13,7 @@ type Props = {
 export default function CheckBox({ id, onChange, checked, disabled = false }: Props) {
     return (
         <input type="checkbox" id={id} checked={checked} onChange={onChange} disabled={disabled}
-            className="h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-2 focus:ring-blue-500 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
+            className="h-5 w-5 rounded-md border-2 border-gray-700 accent-cyan-500 focus:ring-2 focus:ring-cyan-300 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
         />
     );
 }

--- a/components/ui/common/ComboBox.tsx
+++ b/components/ui/common/ComboBox.tsx
@@ -91,7 +91,7 @@ export default function ComboBox({ id, onChange, placeholder = "", value = "", d
 			<input
 				type="text"
 				id={inputId}
-				className={`w-full px-4 py-3 bg-gray-50 border border-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all placeholder:text-gray-400 text-gray-700 disabled:opacity-50 disabled:cursor-not-allowed pr-10 ${isOpen && filteredOptions.length > 0 ? "rounded-t-xl rounded-b-none" : "rounded-xl"}`}
+				className={`w-full px-4 py-3 bg-white border-2 border-gray-700 focus:outline-none focus:border-cyan-500 focus:ring-2 focus:ring-cyan-100 transition-all placeholder:text-gray-400 text-gray-800 font-medium disabled:opacity-50 disabled:cursor-not-allowed pr-10 ${isOpen && filteredOptions.length > 0 ? "rounded-t-xl rounded-b-none" : "rounded-xl"}`}
 				placeholder={placeholder}
 				value={value}
 				onChange={onChange}

--- a/components/ui/common/ComboBoxDropdown.tsx
+++ b/components/ui/common/ComboBoxDropdown.tsx
@@ -24,7 +24,7 @@ export default function ComboBoxDropdown({ isMounted, isOpen, disabled, dropdown
             {options.length > 0 && (options.map((option, index) => (
                 <button type="button" key={option.value} onMouseDown={(e) => e.preventDefault()} onClick={() => onSelect(option.value)}
                     className={`w-full text-left px-4 py-2 transition-colors font-medium ${
-                        option.value === value ? "bg-cyan-50 text-cyan-700 font-black" : index === highlightedIndex ? "bg-gray-100 text-gray-800" : "text-gray-700 hover:bg-gray-50"}`}>
+                        option.value === value ? "bg-cyan-50 text-cyan-700 font-black" : index === highlightedIndex ? "bg-gray-100 text-gray-800 font-medium" : "text-gray-700 hover:bg-gray-50 font-medium"}`}>
                     {option.label}
                 </button>
             )))}

--- a/components/ui/common/ComboBoxDropdown.tsx
+++ b/components/ui/common/ComboBoxDropdown.tsx
@@ -18,13 +18,13 @@ export default function ComboBoxDropdown({ isMounted, isOpen, disabled, dropdown
     if (!isMounted || !isOpen || disabled || options.length === 0) return null;
 
     return createPortal(
-        <div ref={dropdownRef} className="z-50 bg-gray-50 border border-gray-200 border-t-0 rounded-b-xl shadow-lg max-h-56 overflow-y-auto"
+        <div ref={dropdownRef} className="z-50 bg-white border-2 border-gray-700 border-t-0 rounded-b-xl shadow-lg max-h-56 overflow-y-auto"
             style={{ position: "fixed", top: `${position.top}px`, left: `${position.left}px`, width: `${position.width}px` }}
             onMouseDown={(e) => e.preventDefault()}>
             {options.length > 0 && (options.map((option, index) => (
                 <button type="button" key={option.value} onMouseDown={(e) => e.preventDefault()} onClick={() => onSelect(option.value)}
-                    className={`w-full text-left px-4 py-2 transition-colors ${
-                        option.value === value ? "bg-blue-50 text-blue-700" : index === highlightedIndex ? "bg-gray-100 text-gray-700" : "text-gray-700 hover:bg-gray-100"}`}>
+                    className={`w-full text-left px-4 py-2 transition-colors font-medium ${
+                        option.value === value ? "bg-cyan-50 text-cyan-700 font-black" : index === highlightedIndex ? "bg-gray-100 text-gray-800" : "text-gray-700 hover:bg-gray-50"}`}>
                     {option.label}
                 </button>
             )))}

--- a/components/ui/common/Label.tsx
+++ b/components/ui/common/Label.tsx
@@ -10,6 +10,6 @@ type Props = {
 
 export default function Label({ forId, children }: Props) {
     return (
-        <label htmlFor={forId} className="block text-sm font-bold text-gray-700">{children}</label>
+        <label htmlFor={forId} className="block text-sm font-black text-gray-800">{children}</label>
     );
 }

--- a/components/ui/common/NumberSlider.tsx
+++ b/components/ui/common/NumberSlider.tsx
@@ -22,9 +22,9 @@ export default function NumberSlider({ id, onChange, min, max, step, value, disa
     return (
         <div className="px-1">
             <input type="range" id={id} min={min} max={max} step={step} value={value} onChange={onChange} disabled={disabled}
-                className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 disabled:opacity-50 disabled:cursor-not-allowed"
+                   className="w-full h-3 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-200 disabled:opacity-50 disabled:cursor-not-allowed"
             />
-            <div className="flex justify-between text-xs text-gray-400 mt-2 font-medium">
+            <div className="flex justify-between text-xs text-gray-600 mt-2 font-black">
                 {marks.map((mark) => (
                 <span key={mark}>{mark}</span>
                 ))}

--- a/components/ui/common/NumberSliderWithLabel.tsx
+++ b/components/ui/common/NumberSliderWithLabel.tsx
@@ -24,7 +24,7 @@ export default function NumberSliderWithLabel({ onChange, id, min, max, step, va
         <>
             <div className="flex justify-between items-center">
                 <Label forId={id}>{label}</Label>
-                <div className="flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 text-blue-600 font-bold text-sm">
+                <div className="flex items-center justify-center w-8 h-8 rounded-full bg-cyan-500 text-white font-black text-sm">
                     {value}
                 </div>
             </div>

--- a/components/ui/common/TextBox.tsx
+++ b/components/ui/common/TextBox.tsx
@@ -16,7 +16,7 @@ export default function TextBox({ id, onChange, placeholder = "", value = "", di
         <input
             type="text"
             id={id}
-            className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-all placeholder:text-gray-400 text-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="w-full px-4 py-3 bg-white border-2 border-gray-700 rounded-xl focus:outline-none focus:border-cyan-500 focus:ring-2 focus:ring-cyan-100 transition-all placeholder:text-gray-400 text-gray-800 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
             placeholder={placeholder}
             value={value}
             onChange={onChange}

--- a/components/ui/rightpanel/ActionButtons.tsx
+++ b/components/ui/rightpanel/ActionButtons.tsx
@@ -18,7 +18,7 @@ export default function ActionButtons({onRetry, result}: Props) {
     const [showRetryInput, setShowRetryInput] = useState(false);
 
     return (
-        <div className="pt-4 mt-4 border-t border-gray-100">
+        <div className="pt-4 mt-4 border-t-2 border-gray-200">
             <div className={"flex flex-col min-[380px]:flex-row gap-2"}>
                 <RetryButton id="retry-button" showRetryInput={showRetryInput} setShowRetryInput={setShowRetryInput}/>
                 <ShareButton id="share-button" result={result} />

--- a/components/ui/rightpanel/ResultCard.tsx
+++ b/components/ui/rightpanel/ResultCard.tsx
@@ -18,7 +18,7 @@ export default function ResultCard({ result }: Props) {
   const progress = (result.score / 100) * 360;
 
   return (
-    <div id="result-card" className="flex flex-col bg-white p-4 m-2 lg:p-5 z-10 border border-gray-200 rounded-2xl">
+    <div id="result-card" className="flex flex-col bg-white p-4 m-2 lg:p-5 z-10 border-3 border-gray-800 rounded-2xl">
       <span className="flex-1 text-gray-700 text-lg lg:text-xl">
         <span id="excuse-text">{result.excuse}</span>
         <span className="float-right ml-2">

--- a/components/ui/rightpanel/ResultCard.tsx
+++ b/components/ui/rightpanel/ResultCard.tsx
@@ -18,7 +18,7 @@ export default function ResultCard({ result }: Props) {
   const progress = (result.score / 100) * 360;
 
   return (
-    <div id="result-card" className="flex flex-col bg-white p-4 m-2 lg:p-5 z-10 border-3 border-gray-800 rounded-2xl">
+    <div id="result-card" className="flex flex-col bg-white p-4 m-2 lg:p-5 z-10 border-[3px] border-gray-800 rounded-2xl">
       <span className="flex-1 text-gray-700 text-lg lg:text-xl">
         <span id="excuse-text">{result.excuse}</span>
         <span className="float-right ml-2">

--- a/components/ui/rightpanel/ResultCard.tsx
+++ b/components/ui/rightpanel/ResultCard.tsx
@@ -31,7 +31,7 @@ export default function ResultCard({ result }: Props) {
         <span className="text-2xl">{getScoreEmoji(result.score)}</span>
         <div className="flex items-center gap-3">
           <span className="text-xs font-bold text-gray-500 tracking-wide">説得力スコア</span>
-          <div className="relative w-14 h-14 lg:w-16 lg:h-16 rounded-full flex items-center justify-center bg-white shadow-sm border border-gray-100">
+          <div className="relative w-14 h-14 lg:w-16 lg:h-16 rounded-full flex items-center justify-center bg-white">
             {/* スコア表示の円表示 */}
             <div id="score-circle" className={`${styles.circularProgress} absolute inset-0 rounded-full circular-progress`}
               style={{ "--progress": `${progress}deg` } as CSSProperties}></div>

--- a/components/ui/rightpanel/button/RetryButton.tsx
+++ b/components/ui/rightpanel/button/RetryButton.tsx
@@ -20,7 +20,7 @@ export default function RetryButton({id, showRetryInput, setShowRetryInput}: Pro
     };
 
     return (
-        <Button id={id} color="green" onClick={handleRetry}>
+        <Button id={id} color="blue" onClick={handleRetry}>
             <FontAwesomeIcon icon={faTurnUp} />
             もっと盛る
         </Button>

--- a/components/ui/rightpanel/section/ErrorSection.tsx
+++ b/components/ui/rightpanel/section/ErrorSection.tsx
@@ -14,7 +14,7 @@ export default function ErrorSection({error, onResend}: ErrorSectionProps) {
             <div className="text-center space-y-2 text-red-600">
                 <p className="font-bold">エラーが発生しました</p>
                 <p className="text-sm">{error}</p>
-                <Button color="blue" onClick={onResend}>再送する</Button>
+                <Button color="red" onClick={onResend}>再送する</Button>
             </div>
         </div>
     );

--- a/components/ui/rightpanel/section/InitialSection.tsx
+++ b/components/ui/rightpanel/section/InitialSection.tsx
@@ -4,8 +4,9 @@
 export default function InitialSection() {
     return (
         <div className="flex-1 flex items-center justify-center">
-            <div className="text-center text-gray-400">
-                <p>ここには生成後、結果が表示されます</p>
+            <div className="text-center">
+                <p className="text-4xl mb-3">🌲💨🤧</p>
+                <p className="text-gray-400 font-bold">ここには生成後、結果が表示されます</p>
             </div>
         </div>
     );

--- a/components/ui/rightpanel/section/InitialSection.tsx
+++ b/components/ui/rightpanel/section/InitialSection.tsx
@@ -4,9 +4,12 @@
 export default function InitialSection() {
     return (
         <div className="flex-1 flex items-center justify-center">
-            <div className="text-center">
-                <p className="text-4xl mb-3">🌲💨🤧</p>
-                <p className="text-gray-400 font-bold">ここには生成後、結果が表示されます</p>
+            <div className="text-center space-y-4">
+                <p className="text-5xl">🌲💨🤧</p>
+                <div className="bg-cyan-50 border-2 border-gray-800 rounded-2xl px-6 py-4 shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]">
+                    <p className="font-black text-gray-800 text-sm">左のフォームを入力して</p>
+                    <p className="font-black text-pink-500 text-sm">言い訳を生成しよう！</p>
+                </div>
             </div>
         </div>
     );

--- a/components/ui/rightpanel/section/InitialSection.tsx
+++ b/components/ui/rightpanel/section/InitialSection.tsx
@@ -7,7 +7,7 @@ export default function InitialSection() {
             <div className="text-center space-y-4">
                 <p className="text-5xl">🌲💨🤧</p>
                 <div className="bg-cyan-50 border-2 border-gray-800 rounded-2xl px-6 py-4 shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]">
-                    <p className="font-black text-gray-800 text-sm">左のフォームを入力して</p>
+                    <p className="font-black text-gray-800 text-sm">症状などを入力して</p>
                     <p className="font-black text-pink-500 text-sm">言い訳を生成しよう！</p>
                 </div>
             </div>

--- a/components/ui/rightpanel/section/LoadingSection.tsx
+++ b/components/ui/rightpanel/section/LoadingSection.tsx
@@ -5,8 +5,8 @@ export default function LoadingSection() {
     return (
         <div className="flex-1 flex items-center justify-center">
             <div className="text-center space-y-4">
-            <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
-            <p className="text-gray-600 font-medium">言い訳を生成中...</p>
+            <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-4 border-cyan-500"></div>
+            <p className="text-cyan-700 font-black">🌲 言い訳を生成中...</p>
             </div>
         </div>
     );

--- a/components/ui/rightpanel/section/RetryFormSection.tsx
+++ b/components/ui/rightpanel/section/RetryFormSection.tsx
@@ -29,11 +29,11 @@ export default function RetryFormSection({setShowRetryInput, onRetry}: Props) {
     };
 
     return (
-        <div className="space-y-2 border-t border-gray-100 pt-4 mt-4">
+        <div className="space-y-2 border-t-2 border-gray-200 pt-4 mt-4">
             <TextBoxWithLabel id="retry-instruction" label="追加の指示" placeholder="例: もっと怒った感じで" value={retryInstruction}
                 onChange={(e) => setRetryInstruction(e.target.value)}
             />
-            <div className="flex flex-col min-[350px]:flex-row gap-2 border-t border-gray-100 pt-4 mt-4">
+            <div className="flex flex-col min-[350px]:flex-row gap-2 border-t-2 border-gray-200 pt-4 mt-4">
                 <Button id="retry-submit" color="blue" onClick={handleRetrySubmit}>再生成</Button>
                 <Button id="retry-cancel" color="red" onClick={() => setShowRetryInput(false)}>キャンセル</Button>
             </div>


### PR DESCRIPTION
## 概要
`feature/pop-theme-header` でマージされたヘッダーのポップデザイン
（シアン × ピンク × 太枠）に合わせて、残りのすべてのUIコンポーネントをリデザインしました。

## 変更ファイル一覧

### 🌐 app/globals.css
- `--background` CSS変数を `#cffafe`（シアン）に変更し、`body` で `var(--background)` として正しく利用するよう修正

### 📄 app/page.tsx
- `bg-gray-50` を削除（背景色は globals.css で一元管理）
- ヘッダー直下の余白を縮小（`p-4` → `pt-3 pb-4`）

### 📦 components/ui/LeftPanel.tsx
- パネルに太枠（`border-3 border-gray-800`）とネオブルータリズム影（`shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]`）を追加
- 影のクリッピングを防ぐため `m-1` → `m-2` に変更
- 「症状」フィールドにピンクの「必須」バッジを追加して他フィールドと差別化
- 「症状」フィールドのラベル二重生成バグを修正（`TextBoxWithLabel` → `TextBox` 直接利用）
- 位置情報エリアの背景・ボーダーをピンク系（`bg-pink-50 border-2 border-pink-400`）に変更
- 「言い訳を生成する」ボタンを `color="pink"` に変更（メインCTAとして視覚的に強調）
- ボタン上の区切り線を `border-t-2 border-gray-200` に変更

### 📦 components/ui/RightPanel.tsx
- LeftPanel と同様に太枠・影・`m-2` を適用

### 🔘 components/ui/common/Button.tsx
- `DEFAULT_CLASS_NAME`（装飾なし）と `STYLED_CLASS_NAME`（太枠・影付き）を分離
- `color="none"` を装飾なしのシンプルなボタンとして明確化
- 各カラーバリアントが完全なクラスを持つよう再設計（合成スタイルの意図しない重複を解消）
- `"pink"` を型定義と実装に追加
- クリック時の押し込みアニメーション（影3px ↔ translate 3px）を追加
- `className` プロップが渡された場合は `color` を無視するよう優先度を明確化

### ☑️ components/ui/common/CheckBox.tsx
- `border-2 border-gray-700`、`accent-cyan-500`、`focus:ring-cyan-300` でシアン系に統一

### 🔽 components/ui/common/ComboBox.tsx
- `bg-white border-2 border-gray-700`、フォーカス時シアンに変更
- テキストを `text-gray-800 font-medium` でコントラスト強化

### 🔽 components/ui/common/ComboBoxDropdown.tsx
- ドロップダウン枠を `bg-white border-2 border-gray-700` に変更（入力フィールドと統一）
- 選択ハイライトを `bg-blue-50 text-blue-700` → `bg-cyan-50 text-cyan-700 font-black` に変更

### 🏷️ components/ui/common/Label.tsx
- `font-bold text-gray-700` → `font-black text-gray-800` でコントラスト強化

### 🎚️ components/ui/common/NumberSlider.tsx
- スライダーの高さ `h-2` → `h-3` に変更
- `accent-blue-600` → `accent-cyan-500` に統一
- キーボード操作時のフォーカス枠を追加（`focus:ring-2 focus:ring-cyan-200`）
- 目盛り数字を `text-gray-400 font-medium` → `text-gray-600 font-black` で読みやすく

### 🎚️ components/ui/common/NumberSliderWithLabel.tsx
- 現在値バブルを `bg-blue-100 text-blue-600 font-bold` → `bg-cyan-500 text-white font-black` に変更

### 📝 components/ui/common/TextBox.tsx
- `bg-white border-2 border-gray-700`、フォーカス時シアン、`text-gray-800 font-medium` に変更

### ⚡ components/ui/rightpanel/ActionButtons.tsx
- 区切り線を `border-t border-gray-100` → `border-t-2 border-gray-200` に統一

### 📊 components/ui/rightpanel/ResultCard.tsx
- カードに `border-3 border-gray-800` を追加
- スコア円の外枠（`shadow-sm border border-gray-100`）を削除してすっきりした表示に

### ❌ components/ui/rightpanel/section/ErrorSection.tsx
- 「再送する」ボタンを `color="blue"` → `color="red"` に変更（エラー文脈と一致）

### 💬 components/ui/rightpanel/section/InitialSection.tsx
- 灰色テキストのみの表示から、シアン背景・影付き吹き出しカードに変更
- 「左のフォームを入力して / 言い訳を生成しよう！」でユーザーを誘導

### 🔁 components/ui/rightpanel/section/RetryFormSection.tsx
- 区切り線を2箇所とも `border-t-2 border-gray-200` に統一