### PR TITLE
fix: コンボボックスの候補再選択UXを改善

### DIFF
--- a/components/ui/common/ComboBox.tsx
+++ b/components/ui/common/ComboBox.tsx
@@ -19,6 +19,7 @@ type Props = {
 export default function ComboBox({ id, onChange, placeholder = "", value = "", disabled = false, children }: Props) {
 	const generatedId = useId();
 	const inputId = id || generatedId;
+	const dropdownId = `${inputId}-listbox`;
 	const [isOpen, setIsOpen] = useState(false);
 	const [isMounted, setIsMounted] = useState(false);
 	const containerRef = useRef<HTMLDivElement | null>(null);
@@ -36,6 +37,11 @@ export default function ComboBox({ id, onChange, placeholder = "", value = "", d
 			target: { value: nextValue },
 			currentTarget: { value: nextValue },
 		} as ChangeEvent<HTMLInputElement>);
+	};
+
+	const handleSelect = (nextValue: string) => {
+		emitChange(nextValue);
+		setIsOpen(false);
 	};
 
 	const handleBlur = () => {
@@ -66,8 +72,13 @@ export default function ComboBox({ id, onChange, placeholder = "", value = "", d
     }, [filteredOptions]);
 
     // キーボード操作ハンドラ
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (!isOpen || filteredOptions.length === 0) return;
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Escape") {
+			setIsOpen(false);
+			return;
+		}
+
+		if (!isOpen || filteredOptions.length === 0) return;
 
         if (e.key === "ArrowDown") {
             e.preventDefault();
@@ -78,11 +89,8 @@ export default function ComboBox({ id, onChange, placeholder = "", value = "", d
         } else if (e.key === "Enter") {
             e.preventDefault();
             if (highlightedIndex >= 0) {
-                emitChange(filteredOptions[highlightedIndex].value);
-                setIsOpen(false);
+				handleSelect(filteredOptions[highlightedIndex].value);
             }
-        } else if (e.key === "Escape") {
-            setIsOpen(false);
         }
     };
 
@@ -100,6 +108,10 @@ export default function ComboBox({ id, onChange, placeholder = "", value = "", d
                 onKeyDown={handleKeyDown}
 				disabled={disabled}
 				autoComplete="off"
+				role="combobox"
+				aria-expanded={isOpen}
+				aria-controls={dropdownId}
+				aria-autocomplete="list"
 			/>
 			<button
 				type="button"
@@ -108,13 +120,15 @@ export default function ComboBox({ id, onChange, placeholder = "", value = "", d
 				disabled={disabled}
 				className="absolute inset-y-0 right-0 flex items-center px-4 text-gray-500 disabled:cursor-not-allowed"
 				aria-label="候補を表示"
+				aria-expanded={isOpen}
+				aria-controls={dropdownId}
 			>
 				<svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					<path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
 				</svg>
 			</button>
 
-            <ComboBoxDropdown isMounted={isMounted} isOpen={isOpen} disabled={disabled} dropdownRef={dropdownRef} position={position} options={filteredOptions} value={value} onSelect={emitChange} highlightedIndex={highlightedIndex} />
+            <ComboBoxDropdown id={dropdownId} isMounted={isMounted} isOpen={isOpen} disabled={disabled} dropdownRef={dropdownRef} position={position} options={filteredOptions} value={value} onSelect={handleSelect} highlightedIndex={highlightedIndex} />
 		</div>
 	);
 }

--- a/components/ui/common/ComboBoxDropdown.tsx
+++ b/components/ui/common/ComboBoxDropdown.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import type { ComboBoxOption } from "@/hooks/ui/useComboBoxOptions";
 
 type Props = {
+    id: string,
     isMounted: boolean,
     isOpen: boolean,
     disabled: boolean,
@@ -14,20 +15,22 @@ type Props = {
     highlightedIndex: number
 };
 
-export default function ComboBoxDropdown({ isMounted, isOpen, disabled, dropdownRef, position, options, value, onSelect, highlightedIndex }: Props) {
-    if (!isMounted || !isOpen || disabled || options.length === 0) return null;
+export default function ComboBoxDropdown({ id, isMounted, isOpen, disabled, dropdownRef, position, options, value, onSelect, highlightedIndex }: Props) {
+    if (!isMounted || !isOpen || disabled) return null;
 
     return createPortal(
-        <div ref={dropdownRef} className="z-50 bg-white border-2 border-gray-700 border-t-0 rounded-b-xl shadow-lg max-h-56 overflow-y-auto"
+        <div id={id} role="listbox" ref={dropdownRef} className="z-50 bg-white border-2 border-gray-700 border-t-0 rounded-b-xl shadow-lg max-h-56 overflow-y-auto"
             style={{ position: "fixed", top: `${position.top}px`, left: `${position.left}px`, width: `${position.width}px` }}
             onMouseDown={(e) => e.preventDefault()}>
-            {options.length > 0 && (options.map((option, index) => (
+            {options.length > 0 ? (options.map((option, index) => (
                 <button type="button" key={option.value} onMouseDown={(e) => e.preventDefault()} onClick={() => onSelect(option.value)}
                     className={`w-full text-left px-4 py-2 transition-colors font-medium ${
                         option.value === value ? "bg-cyan-50 text-cyan-700 font-black" : index === highlightedIndex ? "bg-gray-100 text-gray-800 font-medium" : "text-gray-700 hover:bg-gray-50 font-medium"}`}>
                     {option.label}
                 </button>
-            )))}
+            ))) : (
+                <div className="px-4 py-3 text-sm text-gray-500">一致する候補がありません</div>
+            )}
         </div>,
         document.body,
     );

--- a/components/ui/common/ComboBoxDropdown.tsx
+++ b/components/ui/common/ComboBoxDropdown.tsx
@@ -17,20 +17,19 @@ type Props = {
 
 export default function ComboBoxDropdown({ id, isMounted, isOpen, disabled, dropdownRef, position, options, value, onSelect, highlightedIndex }: Props) {
     if (!isMounted || !isOpen || disabled) return null;
+    if (options.length <= 0) return null; // 候補がなければそもそもnullにする
 
     return createPortal(
         <div id={id} role="listbox" ref={dropdownRef} className="z-50 bg-white border-2 border-gray-700 border-t-0 rounded-b-xl shadow-lg max-h-56 overflow-y-auto"
             style={{ position: "fixed", top: `${position.top}px`, left: `${position.left}px`, width: `${position.width}px` }}
             onMouseDown={(e) => e.preventDefault()}>
-            {options.length > 0 ? (options.map((option, index) => (
+            {(options.map((option, index) => (
                 <button type="button" key={option.value} onMouseDown={(e) => e.preventDefault()} onClick={() => onSelect(option.value)}
                     className={`w-full text-left px-4 py-2 transition-colors font-medium ${
                         option.value === value ? "bg-cyan-50 text-cyan-700 font-black" : index === highlightedIndex ? "bg-gray-100 text-gray-800 font-medium" : "text-gray-700 hover:bg-gray-50 font-medium"}`}>
                     {option.label}
                 </button>
-            ))) : (
-                <div className="px-4 py-3 text-sm text-gray-500">一致する候補がありません</div>
-            )}
+            )))}
         </div>,
         document.body,
     );

--- a/components/ui/common/ComboBoxDropdown.tsx
+++ b/components/ui/common/ComboBoxDropdown.tsx
@@ -24,11 +24,17 @@ export default function ComboBoxDropdown({ id, isMounted, isOpen, disabled, drop
             style={{ position: "fixed", top: `${position.top}px`, left: `${position.left}px`, width: `${position.width}px` }}
             onMouseDown={(e) => e.preventDefault()}>
             {(options.map((option, index) => (
-                <button type="button" key={option.value} onMouseDown={(e) => e.preventDefault()} onClick={() => onSelect(option.value)}
+                <div
+                    role="option"
+                    aria-selected={option.value === value}
+                    key={option.value}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => onSelect(option.value)}
                     className={`w-full text-left px-4 py-2 transition-colors font-medium ${
-                        option.value === value ? "bg-cyan-50 text-cyan-700 font-black" : index === highlightedIndex ? "bg-gray-100 text-gray-800 font-medium" : "text-gray-700 hover:bg-gray-50 font-medium"}`}>
+                        option.value === value ? "bg-cyan-50 text-cyan-700 font-black" : index === highlightedIndex ? "bg-gray-100 text-gray-800 font-medium" : "text-gray-700 hover:bg-gray-50 font-medium"}`}
+                >
                     {option.label}
-                </button>
+                </div>
             )))}
         </div>,
         document.body,

--- a/hooks/ui/useComboBoxOptions.ts
+++ b/hooks/ui/useComboBoxOptions.ts
@@ -31,8 +31,13 @@ export function useComboBoxOptions(children: ReactNode, keyword: string) {
         const q = keyword.trim().toLowerCase();
         if (!q) return options;
 
+        // 完全一致している場合は、トグル操作時に他候補へ切り替えやすいよう全候補を表示する
+        const hasExactMatch = options.some((option) =>
+            option.label.toLowerCase() === q || option.value.toLowerCase() === q,
+        );
+        if (hasExactMatch) return options;
+
         return options.filter((option) => 
-            option.value.toLowerCase() !== q && // 完全一致は除外
             (option.label.toLowerCase().includes(q) || option.value.toLowerCase().includes(q)));
     }, [options, keyword]);
 


### PR DESCRIPTION
## 概要
「ニュアンス/文体」コンボボックスで、候補を選択後にトグル（▼）を押しても候補が再表示されず、文字列を消さないと再選択できないUX上の問題を修正しました。  
あわせて、候補0件時の表示とキーボード操作・アクセシビリティを改善しています。

## 背景・問題
- 既存実装では `value` が候補と完全一致した場合、フィルタ結果が空になっていた
- そのためトグル押下時に候補が出ず、無反応に見える状態になっていた
- 候補0件時はドロップダウン自体が表示されず、状態が分かりにくかった

## 変更内容
- `hooks/ui/useComboBoxOptions.ts`
  - 完全一致時は候補を除外せず、全候補を返すよう変更
- `components/ui/common/ComboBox.tsx`
  - 候補選択時に確実にドロップダウンを閉じる `handleSelect` を追加
  - `Escape` キーで常に閉じられるよう制御を整理
  - `aria-*` と `role="combobox"` を追加して状態伝達を改善
- `components/ui/common/ComboBoxDropdown.tsx`
  - 候補0件時でも「一致する候補がありません」を表示
  - `id` / `role="listbox"` を追加

## 改善されるUX
- 選択後でもトグルから即座に他候補へ切り替え可能
- 候補がない場合も「無反応」ではなく明確なフィードバックを表示
- キーボード操作（特に `Escape`）の一貫性向上
- スクリーンリーダー向けの状態把握性向上

## 動作確認
- [ ] 候補を1つ選択後、トグル押下で候補一覧が再表示される
- [ ] 別候補に連続して切り替えできる
- [ ] 候補に一致しない文字列入力時、「一致する候補がありません」が表示される
- [ ] `Escape` でドロップダウンが閉じる
- [ ] disabled時に開かない