### PR TITLE
fix: エラーのため、SharePageコンポーネントをSuspenseでラップ

### DIFF
--- a/app/share/page.tsx
+++ b/app/share/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { Suspense } from "react";
 import ShareContent from "./ShareContent";
 import fetchApi from "@/hooks/utils/APIUtil";
 
@@ -54,6 +55,10 @@ export async function generateMetadata({ searchParams }: { searchParams: { id?: 
   };
 }
 
-export default async function SharePage({ searchParams }: { searchParams: { id?: string, text?: string, score?: string } }) {
-  return <ShareContent />;
+export default async function SharePage() {
+  return (
+    <Suspense fallback={null}>
+      <ShareContent />
+    </Suspense>
+  )
 }


### PR DESCRIPTION
- vercel内で エラーのため、SharePageコンポーネントをSuspenseでラップ